### PR TITLE
Fixed pidfile location in rm command

### DIFF
--- a/httpd-shibd-foreground
+++ b/httpd-shibd-foreground
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Apache and Shibd gets grumpy about PID files pre-existing from previous runs
-rm -f /usr/local/apache2/logs/httpd.pid /var/lock/subsys/shibd
+rm -f /etc/httpd/run/httpd.pid /var/lock/subsys/shibd
 
 # Start Shibd
 /etc/shibboleth/shibd-redhat start


### PR DESCRIPTION
httpd-shibd-foreground was looking for the runfile in the Apache base location
and not the CentOS location. Changes to look in the correct location.
/etc/httpd/run is actually a symlink to /run/httpd in this case
but the rm command will still work correctly

Resolves: #5