### PR TITLE
Added chmod to httpd-shibd-foreground

### DIFF
--- a/httpd-shibd-foreground
+++ b/httpd-shibd-foreground
@@ -3,6 +3,9 @@
 # Apache and Shibd gets grumpy about PID files pre-existing from previous runs
 rm -f /etc/httpd/run/httpd.pid /var/lock/subsys/shibd
 
+# Make sure /etc/shibboleth/shibd-redhat is executable
+chmod +x /etc/shibboleth/shibd-redhat
+
 # Start Shibd
 /etc/shibboleth/shibd-redhat start
 


### PR DESCRIPTION
I found that in the latest builds, the execute bit was not set properly on /etc/shibboleth/shibd-redhat .
The problem is likely in the shibboleth package, but this will get the shibd process to start properly till they get that fixed.